### PR TITLE
Add closing iframe tag for embeds

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -337,7 +337,7 @@ function getEntityMarkup(
     return `<img src="${entity.data.src}" style="float:${entity.data.alignment || 'none'};height: ${entity.data.height};width: ${entity.data.width}"/>`;
   }
   if (entity.type === 'EMBEDDED_LINK') {
-    return `<iframe width="${entity.data.width}" height="${entity.data.height}" src="${entity.data.src}" frameBorder="0" />`;
+    return `<iframe width="${entity.data.width}" height="${entity.data.height}" src="${entity.data.src}" frameBorder="0"></iframe>`;
   }
   return text;
 }


### PR DESCRIPTION
The embeds were being rendered as a self closing `<iframe />` tag which doesn't respect the HTML  spec and would cause the cutoff of all the content following it. Adding a closing tag fixes this.

Fixes #12.