### PR TITLE
Fix atomic block check

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -130,8 +130,8 @@ function getSections(
 * Function to check if the block is an atomic entity block.
 */
 function isAtomicEntityBlock(block: Object): boolean {
-  if ((block.entityRanges.length > 0 && isEmptyString(block.text)) ||
-    block.type === 'atomic') {
+  if (block.entityRanges.length > 0 && (isEmptyString(block.text) ||
+    block.type === 'atomic')) {
     return true;
   }
   return false;


### PR DESCRIPTION
Prevents `Uncaught TypeError: Cannot read property 'key' of undefined` when no entity ranges are defined.