### PR TITLE
Fixes #36

### DIFF
--- a/js/__test__/blockTest.js
+++ b/js/__test__/blockTest.js
@@ -136,27 +136,33 @@ describe('addInlineStyleMarkup test suite', () => {
 });
 
 describe('addStylePropertyMarkup test suite', () => {
-  let markup = addStylePropertyMarkup(
-    {
-      COLOR: 'red',
-      BGCOLOR: 'pink',
-      FONTSIZE: 10,
-      FONTFAMILY: 'Arial',
-    },
-    'test'
-  );
-  assert.equal(
-    markup,
-    '<span style="color: red;background-color: pink;font-size: 10px;font-family: Arial;">test</span>',
-  );
-  markup = addStylePropertyMarkup({ COLOR: 'red' }, 'test');
-  assert.equal(markup, '<span style="color: red;">test</span>');
-  markup = addStylePropertyMarkup({ BGCOLOR: 'pink' }, 'test');
-  assert.equal(markup, '<span style="background-color: pink;">test</span>');
-  markup = addStylePropertyMarkup({ FONTFAMILY: 'Arial' }, 'test');
-  assert.equal(markup, '<span style="font-family: Arial;">test</span>');
-  markup = addStylePropertyMarkup({ BOLD: true }, 'test');
-  assert.equal(markup, 'test');
-  markup = addStylePropertyMarkup(undefined, 'test');
-  assert.equal(markup, 'test');
+  it('should correctly add styles based on styles object', () => {
+    let markup = addStylePropertyMarkup(
+      {
+        COLOR: 'red',
+        BGCOLOR: 'pink',
+        FONTSIZE: 10,
+        FONTFAMILY: 'Arial',
+      },
+      'test'
+    );
+    assert.equal(
+      markup,
+      '<span style="color: red;background-color: pink;font-size: 10px;font-family: Arial;">test</span>',
+    );
+    markup = addStylePropertyMarkup({ COLOR: 'red' }, 'test');
+    assert.equal(markup, '<span style="color: red;">test</span>');
+    markup = addStylePropertyMarkup({ BGCOLOR: 'pink' }, 'test');
+    assert.equal(markup, '<span style="background-color: pink;">test</span>');
+    markup = addStylePropertyMarkup({ FONTFAMILY: 'Arial' }, 'test');
+    assert.equal(markup, '<span style="font-family: Arial;">test</span>');
+    markup = addStylePropertyMarkup({ FONTSIZE: 'medium' }, 'test');
+    assert.equal(markup, '<span style="font-size: medium;">test</span>');
+    markup = addStylePropertyMarkup({ FONTSIZE: '24' }, 'test');
+    assert.equal(markup, '<span style="font-size: 24px;">test</span>');
+    markup = addStylePropertyMarkup({ BOLD: true }, 'test');
+    assert.equal(markup, 'test');
+    markup = addStylePropertyMarkup(undefined, 'test');
+    assert.equal(markup, 'test');
+  });
 });

--- a/js/block.js
+++ b/js/block.js
@@ -298,7 +298,7 @@ export function addStylePropertyMarkup(styles: Object, text: string): string {
       styleString += `background-color: ${styles.BGCOLOR};`;
     }
     if (styles.FONTSIZE) {
-      styleString += `font-size: ${styles.FONTSIZE}px;`;
+      styleString += `font-size: ${styles.FONTSIZE}${/^\d+$/.test(styles.FONTSIZE) ? 'px' : ''};`;
     }
     if (styles.FONTFAMILY) {
       styleString += `font-family: ${styles.FONTFAMILY};`;


### PR DESCRIPTION
Related to https://github.com/jpuri/draftjs-to-html/issues/36

This change checks whether the font-size looks like a number before adding 'px' to the end of it. This prevents outputting styles such as `font-size: mediumpx`.

It's worth noting that this assumes that all font-sizes which are numbers are pixels (rather than percentages, `em`s, `rem`s etc), but that assumption has always been true, so I don't hink it needs addressing right now.