### PR TITLE
Fix bug that was causing emojis to split

### DIFF
--- a/js/__test__/mainTest.js
+++ b/js/__test__/mainTest.js
@@ -115,4 +115,12 @@ describe('draftToHtml test suite', () => {
     result = draftToHtml(convertToRaw(contentState));
     assert.equal(html, result);
   });
+
+  it('should return correct result when there are emojis', () => {
+    const html = '<p><strong>👈</strong>👈</p>\n';
+    const arrContentBlocks = convertFromHTML(html);
+    const contentState = ContentState.createFromBlockArray(arrContentBlocks);
+    const result = draftToHtml(convertToRaw(contentState));
+    assert.equal(html, result);
+  });
 });

--- a/js/block.js
+++ b/js/block.js
@@ -352,7 +352,7 @@ function getInlineStyleSections(
   end: number,
 ): Array<Object> {
   const styleSections = [];
-  const { text } = block;
+  const text = Array.from(block.text)
   if (text.length > 0) {
     const inlineStyles = getStyleArrayForBlock(block);
     let section;


### PR DESCRIPTION
Fixes https://github.com/jpuri/draftjs-to-html/issues/24.

Added a test first to see if it failed and it did:
```
  17 passing (85ms)
  1 failing

  1) draftToHtml test suite
       should return correct result when there are emojis:

      AssertionError: expected '<p><strong>👈</strong>👈</p>\n' to equal '<p><strong>�</strong>�👈</p>\n'
      + expected - actual

      -<p><strong>👈</strong>👈</p>
      +<p><strong>�</strong>�👈</p>
      
      at Context.<anonymous> (js/__test__/mainTest.js:124:12)
```
After the fix:
```
  18 passing (67ms)

✨  Done in 1.67s.
```