### PR TITLE
fix(lists): append nested lists when we hit a new list type

### DIFF
--- a/js/__test__/mainTest.js
+++ b/js/__test__/mainTest.js
@@ -54,6 +54,13 @@ describe('draftToHtml test suite', () => {
     contentState = ContentState.createFromBlockArray(arrContentBlocks);
     result = draftToHtml(convertToRaw(contentState));
     assert.equal(output, result);
+
+    html = '<ul>\n<li>1</li>\n<ul>\n<li>2</li>\n</ul>\n</ul>\n<ol>\n<li>3</li>\n<li>4</li>\n</ol>\n';
+    output = '<ul>\n<li>1</li>\n<ul>\n<li>2</li>\n</ul>\n</ul>\n<ol>\n<li>3</li>\n<li>4</li>\n</ol>\n';
+    arrContentBlocks = convertFromHTML(html);
+    contentState = ContentState.createFromBlockArray(arrContentBlocks);
+    result = draftToHtml(convertToRaw(contentState));
+    assert.equal(output, result);
   });
 
   it('should return correct result for inline styles color', () => {

--- a/js/list.js
+++ b/js/list.js
@@ -32,6 +32,19 @@ export function getListMarkup(
     if (!previousBlock) {
       listHtml.push(`<${getBlockTag(block.type)}>\n`);
     } else if (previousBlock.type !== block.type) {
+      if (nestedListBlock && nestedListBlock.length > 0) {
+        listHtml.push(
+          getListMarkup(
+            nestedListBlock,
+            entityMap,
+            hashtagConfig,
+            directional,
+            customEntityTransform,
+          ),
+        );
+        nestedListBlock = [];
+      }
+
       listHtml.push(`</${getBlockTag(previousBlock.type)}>\n`);
       listHtml.push(`<${getBlockTag(block.type)}>\n`);
     } else if (previousBlock.depth === block.depth) {


### PR DESCRIPTION
List calculation was prematurely breaking out of a nested list when encountering a new list type. This change ensures any nested lists get appended before switching to the new list type

before:
```
<ul>
<li>1</li>
</ul>
<ol>
<li>3</li>
<ul>
<li>2</li>
</ul>
<li>4</li>
</ol>
```

after:
```
<ul>
<li>1</li>
<ul>
<li>2</li>
</ul>
</ul>
<ol>
<li>3</li>
<li>4</li>
</ol>
```