### PR TITLE
Added a missing argument in getListMarkup

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -22,7 +22,7 @@ export default function draftToHtml(
           listBlocks.push(block);
         } else {
           if (listBlocks.length > 0) {
-            const listHtml = getListMarkup(listBlocks, entityMap, hashtagConfig, customEntityTransform); // eslint-disable-line max-len
+            const listHtml = getListMarkup(listBlocks, entityMap, hashtagConfig, directional, customEntityTransform); // eslint-disable-line max-len
             html.push(listHtml);
             listBlocks = [];
           }

--- a/lib/draftjs-to-html.js
+++ b/lib/draftjs-to-html.js
@@ -694,7 +694,7 @@
             listBlocks.push(block);
           } else {
             if (listBlocks.length > 0) {
-              var listHtml = getListMarkup(listBlocks, entityMap, hashtagConfig, customEntityTransform); // eslint-disable-line max-len
+              var listHtml = getListMarkup(listBlocks, entityMap, hashtagConfig, directional, customEntityTransform); // eslint-disable-line max-len
 
               html.push(listHtml);
               listBlocks = [];


### PR DESCRIPTION
I know this project is abandoned, but I hope this major issue fix will be merged and released one day.

The usage of the getListMarkup function is missing an argument, so customEntityTransform never calls for a listBlocks if after it non-list block is added.